### PR TITLE
added name property to materials

### DIFF
--- a/issue.html
+++ b/issue.html
@@ -29,7 +29,8 @@
             specular: 0xfafafa, //bbaa99,
             shininess: 70,
             emissive: 0x000000,
-            reflectivity: 0.7
+            reflectivity: 0.7,
+            name: "Book_Cover"
 
 
         })
@@ -45,7 +46,8 @@
             emissiveIntensity: null,
             //	envMap: textureCube,
             //	combine: THREE.MixOperation,
-            reflectivity: 0.1
+            reflectivity: 0.1,
+            name: "Book_Cover"
         });
 
         var cleanWhite = new THREE.MeshPhongMaterial({
@@ -53,7 +55,8 @@
             color: 0xffffef,
             specular: 0x000000,
             combine: THREE.AddOperation,
-            reflectivity: 0
+            reflectivity: 0,
+            name: "Book_Cover"
         })
 
 


### PR DESCRIPTION
When a keydown event is emitted and the "C" key is pressed, we traverse the object and check to see if the indexed child is a mesh and if its material name is "Book_Cover". But the materials that we've assigned to the colors array didn't have a name so the code within the condition wasn't executed as expected.
